### PR TITLE
3.2.1 Fix for add_child() -> call_deferred

### DIFF
--- a/Enemy.gd
+++ b/Enemy.gd
@@ -28,5 +28,5 @@ func add_to_score():
 func create_explosion():
 	var main = get_tree().current_scene
 	var explosionEffect = ExplosionEffect.instance()
-	main.add_child(explosionEffect)
+	main.call_deferred("add_child", explosionEffect)
 	explosionEffect.global_position = global_position

--- a/EnemySpawner.gd
+++ b/EnemySpawner.gd
@@ -13,7 +13,7 @@ func spawn_enemy():
 	var spawn_position = get_spawn_position()
 	var enemy = Enemy.instance()
 	var main = get_tree().current_scene
-	main.add_child(enemy)
+	main.call_deferred("add_child", enemy)
 	enemy.global_position = spawn_position
 
 func _on_Timer_timeout():

--- a/Laser.gd
+++ b/Laser.gd
@@ -10,6 +10,6 @@ func _ready():
 func create_hit_effect():
 	var main = get_tree().current_scene
 	var hitEffect = HitEffect.instance()
-	main.add_child(hitEffect)
+	main.call_deferred("add_child", hitEffect)
 	hitEffect.global_position = global_position
 

--- a/Ship.gd
+++ b/Ship.gd
@@ -24,7 +24,7 @@ func fire_laser():
 func _exit_tree():
 	var main = get_tree().current_scene
 	var explosionEffect = ExplosionEffect.instance()
-	main.add_child(explosionEffect)
+	main.call_deferred("add_child", explosionEffect)
 	explosionEffect.global_position = global_position
 	emit_signal("player_death")
 


### PR DESCRIPTION
Working through your 1-bit course with the current version of Godot. For any github'ers, this should fix the errors:

```
E 0:00:03.478   add_child: Parent node is busy setting up children, add_node() failed. Consider using call_deferred("add_child", child) instead.
  <C++ Error>   Condition "data.blocked > 0" is true.
  <C++ Source>  scene/main/node.cpp:1177 @ add_child()
  <Stack Trace> {file_name}.gd:{line#} @ _exit_tree()
```