### PR TITLE
Bug - Highscore save file is in the wrong path

### DIFF
--- a/SaveAndLoad.gd
+++ b/SaveAndLoad.gd
@@ -1,6 +1,6 @@
 extends Node
 
-const SAVE_DATA_PATH = "res://save_data.json"
+const SAVE_DATA_PATH = "user://save_data.json"
 var default_save_data = {
 	highscore = 0
 }


### PR DESCRIPTION
It should use the `user://` path, then you'll see it exactly where you've shown in the video